### PR TITLE
fix: use getKey for has

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ export class IDBBlockstore extends BaseBlockstore {
     }
 
     try {
-      return Boolean(await this.db.get(this.location, this.#encode(key)))
+      return Boolean(await this.db.getKey(this.location, this.#encode(key)))
     } catch (err: any) {
       throw Errors.putFailedError(err)
     }


### PR DESCRIPTION
No need to retrive the whole block